### PR TITLE
Mvp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Thumbs.db
+.DS_Store
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Meta files
 Thumbs.db
 .DS_Store
 .vscode
+.idea
+
+# config files
+.donner.yml
+
+# bin
+donner

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Jonas-Taha El Sesiy & Julian Fahrer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Donner
+[![Go Report Card](https://goreportcard.com/badge/github.com/jfahrer/donner)](https://goreportcard.com/report/github.com/jfahrer/donner)
 
 :boom: Donner is a generic command wrapper. It let's you define strategies to wrap commands in things like `docker-compose exec` or `docker container run`.  
 This is can come in very handy when developing applications in containers.  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Donner
 
-Donner is a generic command wrapper. It let's you define strategies to wrap commands in things like `docker-compose exec` or `docker container run`. This is can come in very handy when developing applications in containers. Donner allows defining a wrapping strategy on a per command basis. So you don't have to worry which service to use or whether you should use `docker-compose exec` or `docker-compose run` when executing a command.
+:boom: Donner is a generic command wrapper. It let's you define strategies to wrap commands in things like `docker-compose exec` or `docker container run`.  
+This is can come in very handy when developing applications in containers.  
+Donner allows defining a wrapping strategy on a per command basis. So you don't have to worry which service to use or whether you should use `docker-compose exec` or `docker-compose run` when executing a command.
 
 ## Examples
 

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,5 @@
+package config
+
+func Foobar() int {
+	return 9001
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,0 @@
-package config
-
-func Foobar() int {
-	return 9001
-}

--- a/donner.go
+++ b/donner.go
@@ -40,12 +40,12 @@ func main() {
 					return err
 				}
 
-				cfg, err := ParseFile(dat)
+				cfg, err := parseFile(dat)
 				if err != nil {
 					return err
 				}
 
-				return ExecCommand(cfg, c.Args())
+				return execCommand(cfg, c.Args())
 			},
 		},
 		{
@@ -64,8 +64,8 @@ func main() {
 	}
 }
 
-// ExecCommand dispatches the call to the OS
-func ExecCommand(cfg *Cfg, params []string) error {
+// execCommand dispatches the call to the OS
+func execCommand(cfg *Cfg, params []string) error {
 	if len(params) < 1 {
 		// TODO show usage?
 		return ErrMissingCommand

--- a/donner.go
+++ b/donner.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
+
+	"github.com/jfahrer/donner/config"
 
 	"github.com/urfave/cli"
 )
@@ -13,6 +16,18 @@ func main() {
 	app.Name = "Donner"
 	app.Usage = "Donner is a generic command wrapper. It let's you define strategies to wrap commands in things like `docker-compose exec` or `docker container run`. This is can come in very handy when developing applications in containers. Donner allows defining a wrapping strategy on a per command basis. So you don't have to worry which service to use or whether you should use `docker-compose exec` or `docker-compose run` when executing a command."
 	app.Commands = []cli.Command{
+		{
+			Name:    "test",
+			Aliases: []string{"t"},
+			Usage:   "run a command",
+			Action: func(c *cli.Context) error {
+				command := []string{"ls", "-l"}
+				command = append(command, c.Args()...)
+				out, _ := exec.Command(command[0], command[1:]...).Output()
+				fmt.Println(string(out[:]))
+				return nil
+			},
+		},
 		{
 			Name:    "run",
 			Aliases: []string{"r"},
@@ -26,6 +41,10 @@ func main() {
 				// fallbackMode := c.Bool("fallback")
 				fmt.Println(len(c.Args()))
 				fmt.Println(c.Args())
+				fmt.Println(config.Foobar())
+				command := []string{"docker-compose", "exec", "app"}
+				command = append(command, c.Args()...)
+				fmt.Println(command)
 				return nil
 			},
 		},

--- a/donner.go
+++ b/donner.go
@@ -1,58 +1,56 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"github.com/urfave/cli"
 	"io/ioutil"
 	"log"
 	"os"
-
-	"github.com/urfave/cli"
+	"os/exec"
 )
+
+// ErrUndefinedCommand is thrown if a command specified can't be found in the yaml definition
+var ErrUndefinedCommand = errors.New("the command you're trying to run doesn't exist in the yaml definition")
+// ErrMissingCommand is thrown if no handler for execution is provided
+var ErrMissingCommand = errors.New("no command for execution specified")
 
 func main() {
 	app := cli.NewApp()
 	app.Name = "Donner"
-	app.Usage = `Donner is a generic command wrapper. It let's you define strategies to wrap commands in things like 'docker-compose exec' or 'docker container run'. 
-	This is can come in very handy when developing applications in containers. Donner allows defining a wrapping strategy on a per command basis. 
-	So you don't have to worry which service to use or whether you should use 'docker-compose exec' or 'docker-compose run' when executing a command.`
+	app.Usage = `Donner is a generic command wrapper. It let's you define strategies to wrap commands in things like 'docker-compose exec' or 'docker container run'.
+	 This is can come in very handy when developing applications in containers. Donner allows defining a wrapping strategy on a per command basis. 
+	 So you don't have to worry which service to use or whether you should use 'docker-compose exec' or 'docker-compose run' when executing a command.`
+	// TODO implement flags
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{Name: "strict,s", Usage: "enable strict mode"},
+		cli.BoolFlag{Name: "fallback,f", Usage: "fallback to local commands"},
+	}
 	app.Commands = []cli.Command{
 		{
-			Name:    "run",
-			Aliases: []string{"r"},
-			Usage:   "run a command",
-			Flags: []cli.Flag{
-				cli.BoolFlag{Name: "strict,s", Usage: "enable strict mode"},
-				cli.BoolFlag{Name: "fallback,f", Usage: "fallback to local commands"},
-			},
+			Name:            "run",
+			Aliases:         []string{"r"},
+			Usage:           "run a command",
+			SkipFlagParsing: true,
 			Action: func(c *cli.Context) error {
-				command := []string{"docker-compose", "exec", "app"}
-				command = append(command, c.Args()...)
-
 				// TODO handle 'yaml' case
 				dat, err := ioutil.ReadFile(".donner.yml")
 				if err != nil {
 					return err
 				}
 
-				res, err := ParseFile(dat)
+				cfg, err := ParseFile(dat)
 				if err != nil {
 					return err
 				}
 
-				// TODO dispatch os call
-				fmt.Printf("%+v", res)
-
-				return nil
+				return ExecCommand(cfg, c.Args())
 			},
 		},
 		{
 			Name:    "aliases",
 			Aliases: []string{"a"},
-			Flags: []cli.Flag{
-				cli.BoolFlag{Name: "strict,s", Usage: "enable strict mode"},
-				cli.BoolFlag{Name: "fallback,f", Usage: "fallback to local commands"},
-			},
-			Usage: "generate aliases",
+			Usage:   "generate aliases",
 			Action: func(c *cli.Context) error {
 				return nil
 			},
@@ -63,4 +61,49 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+}
+
+// ExecCommand dispatches the call to the OS
+func ExecCommand(cfg *Cfg, params []string) error {
+	if len(params) < 1 {
+		// TODO show usage?
+		return ErrMissingCommand
+	}
+
+	// check if command specified exists in parsed file
+	command, ok := cfg.Commands[params[0]]
+	if !ok {
+		return ErrUndefinedCommand
+	}
+
+	// extract handler from corresponding strategy
+	designatedHandler := cfg.Strategies[string(command)]
+	execHandler := availableHandlers[designatedHandler.Handler]
+
+	// construct os call
+	cliArgs := []string{execHandler.Argument}
+
+	if designatedHandler.Remove {
+		cliArgs = append(cliArgs, "--rm")
+	}
+
+	if designatedHandler.Image != "" {
+		cliArgs = append(cliArgs, designatedHandler.Image)
+	}
+
+	for _, p := range params {
+		cliArgs = append(cliArgs, p)
+	}
+
+	cmd := exec.Command(execHandler.BaseCommand, cliArgs...)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return err
+	}
+
+	// TODO structured output?
+	fmt.Println(string(out))
+
+	return nil
 }

--- a/donner.go
+++ b/donner.go
@@ -19,12 +19,18 @@ func main() {
 		{
 			Name:    "test",
 			Aliases: []string{"t"},
-			Usage:   "run a command",
+			Usage:   "testing",
 			Action: func(c *cli.Context) error {
-				command := []string{"ls", "-l"}
+				command := []string{"docker", "container", "run"}
 				command = append(command, c.Args()...)
-				out, _ := exec.Command(command[0], command[1:]...).Output()
-				fmt.Println(string(out[:]))
+				// Simple run the programm
+				// out, _ := exec.Command(command[0], command[1:]...).Output()
+				// fmt.Println(string(out[:]))
+				cmd := exec.Command(command[0], command[1:]...)
+				cmd.Stdout = os.Stdout
+				cmd.Stdin = os.Stdin
+				cmd.Stderr = os.Stderr
+				cmd.Run()
 				return nil
 			},
 		},

--- a/donner.go
+++ b/donner.go
@@ -12,6 +12,7 @@ import (
 
 // ErrUndefinedCommand is thrown if a command specified can't be found in the yaml definition
 var ErrUndefinedCommand = errors.New("the command you're trying to run doesn't exist in the yaml definition")
+
 // ErrMissingCommand is thrown if no handler for execution is provided
 var ErrMissingCommand = errors.New("no command for execution specified")
 
@@ -85,6 +86,10 @@ func ExecCommand(cfg *Cfg, params []string) error {
 
 	if designatedHandler.Remove {
 		cliArgs = append(cliArgs, "--rm")
+	}
+
+	if designatedHandler.Service != "" {
+		cliArgs = append(cliArgs, designatedHandler.Service)
 	}
 
 	if designatedHandler.Image != "" {

--- a/donner.go
+++ b/donner.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/jfahrer/donner/config"
 
@@ -30,7 +31,19 @@ func main() {
 				cmd.Stdout = os.Stdout
 				cmd.Stdin = os.Stdin
 				cmd.Stderr = os.Stderr
-				cmd.Run()
+				var waitStatus syscall.WaitStatus
+				if err := cmd.Run(); err != nil {
+					if err != nil {
+						os.Stderr.WriteString(fmt.Sprintf("Error: %s\n", err.Error()))
+					}
+					if exitError, ok := err.(*exec.ExitError); ok {
+						waitStatus = exitError.Sys().(syscall.WaitStatus)
+						os.Exit(waitStatus.ExitStatus())
+					}
+				} else {
+					// Success
+					os.Exit(waitStatus.ExitStatus())
+				}
 				return nil
 			},
 		},

--- a/donner_test.go
+++ b/donner_test.go
@@ -24,7 +24,7 @@ func TestExecCommand(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := ExecCommand(test.config, test.params)
+			err := execCommand(test.config, test.params)
 			assert.EqualError(t, err, test.expErr.Error())
 		})
 	}

--- a/donner_test.go
+++ b/donner_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestExecCommand(t *testing.T) {
+	tests := map[string]struct {
+		config *Cfg
+		params []string
+		expErr error
+	}{
+		"missing command": {
+			config: &Cfg{Strategies: map[string]Strategy{}},
+			expErr: ErrMissingCommand,
+		},
+		"undefined command": {
+			config: &Cfg{Strategies: map[string]Strategy{"test": {Handler: "test"}}, Commands: map[string]Command{"golang": "exec"}},
+			params: []string{"invalid"},
+			expErr: ErrUndefinedCommand,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := ExecCommand(test.config, test.params)
+			assert.EqualError(t, err, test.expErr.Error())
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,10 @@ module github.com/jfahrer/donner
 
 go 1.12
 
-require github.com/urfave/cli v1.20.0 // indirect
+require (
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/testify v1.3.0
+	github.com/urfave/cli v1.20.0
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/yaml.v2 v2.2.2
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/jfahrer/donner
+
+go 1.12
+
+require github.com/urfave/cli v1.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
+github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,16 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/parser.go
+++ b/parser.go
@@ -1,0 +1,34 @@
+package main
+
+import "gopkg.in/yaml.v2"
+
+// Cfg is the uber object in our YAML file
+type Cfg struct {
+	Strategies      map[string]Strategy
+	DefaultStrategy string `yaml:"default_strategy"`
+	Commands        map[string]Command
+}
+
+// Strategy is the definition of a
+type Strategy struct {
+	Handler string
+	Service string
+	Remove  bool
+}
+
+// Command is an alias for string to properly reflect the yaml definition
+type Command string
+
+// ParseFile processes the .donner.yml file
+func ParseFile(file []byte) (*Cfg, error) {
+	cfg := Cfg{}
+	err := yaml.Unmarshal([]byte(file), &cfg)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO validate config
+
+	return &cfg, nil
+}

--- a/parser.go
+++ b/parser.go
@@ -63,8 +63,8 @@ func (s *Strategy) Validate() error {
 // Command is an alias for string to properly reflect the yaml definition
 type Command string
 
-// ParseFile processes the .donner.yml file
-func ParseFile(file []byte) (*Cfg, error) {
+// parseFile processes the .donner.yml file
+func parseFile(file []byte) (*Cfg, error) {
 	cfg := Cfg{}
 	err := yaml.Unmarshal([]byte(file), &cfg)
 

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,21 @@
 package main
 
-import "gopkg.in/yaml.v2"
+import (
+	"errors"
+	"gopkg.in/yaml.v2"
+)
+
+// ErrInvalidHandler is thrown if any handler that is unknown to the program is specified
+var ErrInvalidHandler = errors.New("configuration specifies unknown handler")
+
+// Current handler implementations
+var availableHandlers = map[string]ExecHandler{"docker_compose_run": {"docker-compose", "run"}, "docker_compose_exec": {"docker-compose", "exec"}, "docker_run": {"docker", "run"}}
+
+// ExecHandler is the desired OS exec
+type ExecHandler struct {
+	BaseCommand string
+	Argument    string
+}
 
 // Cfg is the uber object in our YAML file
 type Cfg struct {
@@ -14,6 +29,17 @@ type Strategy struct {
 	Handler string
 	Service string
 	Remove  bool
+	Image   string
+}
+
+// Validate checks whether a strategy specifies only valid handlers
+func (s *Strategy) Validate() error {
+	_, ok := availableHandlers[s.Handler]
+	if !ok {
+		return ErrInvalidHandler
+	}
+
+	return nil
 }
 
 // Command is an alias for string to properly reflect the yaml definition
@@ -28,7 +54,11 @@ func ParseFile(file []byte) (*Cfg, error) {
 		return nil, err
 	}
 
-	// TODO validate config
+	for _, strat := range cfg.Strategies {
+		if err := strat.Validate(); err != nil {
+			return nil, err
+		}
+	}
 
 	return &cfg, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -17,7 +17,7 @@ strategies:
     service: app
 `
 
-func TestParsing(t *testing.T) {
+func TestParseFile(t *testing.T) {
 	// TODO add many more tests
 	tests := map[string]struct {
 		input  string

--- a/parser_test.go
+++ b/parser_test.go
@@ -6,25 +6,45 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var data = `
+var missingCommandsYaml = `
 strategies:
-  run:
-    handler: docker_compose_run
-    service: app
-    remove: true
   exec:
     handler: docker_compose_exec
     service: app
 `
 
+var missingStrategiesYml = `
+commands:
+  rails: exec
+  rspec: exec
+`
+
+var fullYaml = `
+strategies:
+  run:
+    handler: docker_compose_run
+    service: app
+    remove: true
+  run_with_docker:
+    handler: docker_run
+    image: alpine:latest
+
+default_strategy: run
+
+commands:
+  ls: run_with_docker
+  bundle: run
+`
+
 func TestParseFile(t *testing.T) {
-	// TODO add many more tests
 	tests := map[string]struct {
 		input  string
 		exp    *Cfg
 		expErr error
 	}{
-		"partial valid yaml": {data, &Cfg{Strategies: map[string]Strategy{"exec": Strategy{Handler: "docker_compose_exec", Service: "app", Remove: false}, "run": Strategy{Handler: "docker_compose_run", Service: "app", Remove: true}}, DefaultStrategy: "", Commands: map[string]Command(nil)}, nil},
+		"yaml without commands":   {input: missingCommandsYaml, expErr: ErrNoCommandsSpecified},
+		"yaml without strategies": {input: missingStrategiesYml, expErr: ErrNoStrategiesSpecified},
+		"full yaml spec":          {input: fullYaml, exp: &Cfg{Strategies: map[string]Strategy{"run": {Handler: "docker_compose_run", Service: "app", Remove: true}, "run_with_docker": {Handler: "docker_run", Image: "alpine:latest"}}, DefaultStrategy: "run", Commands: map[string]Command{"ls": "run_with_docker", "bundle": "run"}}},
 	}
 
 	for name, test := range tests {

--- a/parser_test.go
+++ b/parser_test.go
@@ -49,7 +49,7 @@ func TestParseFile(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			res, err := ParseFile([]byte(test.input))
+			res, err := parseFile([]byte(test.input))
 			if test.expErr != nil {
 				assert.Error(t, err, test.expErr.Error())
 			} else {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var data = `
+strategies:
+  run:
+    handler: docker_compose_run
+    service: app
+    remove: true
+  exec:
+    handler: docker_compose_exec
+    service: app
+`
+
+func TestParsing(t *testing.T) {
+	// TODO add many more tests
+	tests := map[string]struct {
+		input  string
+		exp    *Cfg
+		expErr error
+	}{
+		"partial valid yaml": {data, &Cfg{Strategies: map[string]Strategy{"exec": Strategy{Handler: "docker_compose_exec", Service: "app", Remove: false}, "run": Strategy{Handler: "docker_compose_run", Service: "app", Remove: true}}, DefaultStrategy: "", Commands: map[string]Command(nil)}, nil},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := ParseFile([]byte(test.input))
+			if test.expErr != nil {
+				assert.Error(t, err, test.expErr.Error())
+			} else {
+				assert.Equal(t, test.exp, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the following capabilities:
- Parsing of `.donner.yml` file
- Validation of the existence of commands & strategies
- Initial specification of three supported handlers: `docker_compose_exec`, `docker_compose_run` and `docker_run`
- Tests for parsing of yml specs & errors during validation
- License

So far, no support has been added for volume mounts, aliases, flags, default strategy and required params for certain strategies such as Image for `docker_run`.