### PR TITLE
Allow interactive commands and return correct exit code

### DIFF
--- a/donner.go
+++ b/donner.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"syscall"
 
 	"github.com/urfave/cli"
 )
@@ -86,7 +87,7 @@ func execCommand(cfg *Cfg, params []string) error {
 	execHandler := availableHandlers[designatedHandler.Handler]
 
 	// construct os call
-	cliArgs := []string{execHandler.Argument}
+	cliArgs := execHandler.Args
 
 	if designatedHandler.Remove {
 		cliArgs = append(cliArgs, "--rm")
@@ -105,14 +106,21 @@ func execCommand(cfg *Cfg, params []string) error {
 	}
 
 	cmd := exec.Command(execHandler.BaseCommand, cliArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
 
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return err
+	if err := cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			// This block ensures that we return the same exit code in case the command failed
+			waitStatus := exitError.Sys().(syscall.WaitStatus)
+			os.Exit(waitStatus.ExitStatus())
+		} else {
+			// This block handles the case where Donner could not start the command at all (missing, permission, ...)
+			_, _ = os.Stderr.WriteString(fmt.Sprintf("%s\n", err.Error()))
+			os.Exit(1) // TODO: What would be a good exit code to return here?
+		}
 	}
-
-	// TODO structured output?
-	fmt.Println(string(out))
 
 	return nil
 }

--- a/parser.go
+++ b/parser.go
@@ -7,7 +7,12 @@ import (
 )
 
 // Current handler implementations
-var availableHandlers = map[string]ExecHandler{"docker_compose_run": {"docker-compose", "run"}, "docker_compose_exec": {"docker-compose", "exec"}, "docker_run": {"docker", "run"}}
+var availableHandlers = map[string]ExecHandler{
+	"docker_compose_run":  {"docker-compose", []string{"run"}},
+	"docker_compose_exec": {"docker-compose", []string{"exec"}},
+	"docker_run":          {"docker", []string{"run", "-it"}},
+	"missing_executable":  {"i_am_not_an_executable_in_path", []string{}},
+}
 
 // ErrInvalidHandler is thrown if any handler that is unknown to the program is specified
 var ErrInvalidHandler = errors.New("configuration specifies unknown handler")
@@ -21,7 +26,7 @@ var ErrNoStrategiesSpecified = errors.New("the specified yaml file doesn't conta
 // ExecHandler is the desired OS exec
 type ExecHandler struct {
 	BaseCommand string
-	Argument    string
+	Args        []string
 }
 
 // Cfg is the uber object in our YAML file


### PR DESCRIPTION
This will
1) forward the output to stdout before the command finishes
2) allow starting interactive applications like a shell