### PR TITLE
Append a semicolon to aliases

### DIFF
--- a/aliases.go
+++ b/aliases.go
@@ -25,7 +25,7 @@ func printAliases(cfg *Cfg, strictMode, fallbackMode bool) {
 
 	fmt.Println()
 	for i, c := range commands {
-		fmt.Printf("alias %s='donner run %s'\n", c, outputs[i])
+		fmt.Printf("alias %s='donner run %s';\n", c, outputs[i])
 	}
 
 	aliasCommand := strings.Join(append([]string{"donner", "aliases"}, flags...), " ")

--- a/donner.go
+++ b/donner.go
@@ -18,7 +18,7 @@ var ErrMissingCommand = errors.New("no command for execution specified")
 func main() {
 	app := cli.NewApp()
 	app.Name = "Donner"
-	app.Version = "0.1.0"
+	app.Version = "0.1.1"
 	app.Usage = `Donner is a generic command wrapper. It let's you define strategies to wrap commands in things like 'docker-compose exec' or 'docker container run'.
 	 This is can come in very handy when developing applications in containers. Donner allows defining a wrapping strategy on a per command basis. 
 	 So you don't have to worry which service to use or whether you should use 'docker-compose exec' or 'docker-compose run' when executing a command.`


### PR DESCRIPTION
With the semicolon we can actually set aliases via `eval $(donner aliases)`