### PR TITLE
Feat/volume port support docker run

### DIFF
--- a/aliases.go
+++ b/aliases.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"strings"
 )
 
-func printAliases(cfg *Cfg, strictMode, fallbackMode bool) {
+const evalInstruction = "\n# copy and paste the output into your terminal or run\n"
+
+func printAliases(w io.Writer, cfg *Cfg, strictMode, fallbackMode bool) {
 	commands := cfg.ListCommands()
 	outputs := make([]string, len(commands))
 
@@ -25,11 +28,11 @@ func printAliases(cfg *Cfg, strictMode, fallbackMode bool) {
 
 	fmt.Println()
 	for i, c := range commands {
-		fmt.Printf("alias %s='donner run %s';\n", c, outputs[i])
+		_, _ = fmt.Fprintf(w, "alias %s='donner run %s';\n", c, outputs[i])
 	}
 
 	aliasCommand := strings.Join(append([]string{"donner", "aliases"}, flags...), " ")
 
-	fmt.Printf("\n# copy and paste the output into your terminal or run\n")
-	fmt.Printf("#  eval $(%s)\n", aliasCommand)
+	_, _ = fmt.Fprintf(w, evalInstruction)
+	_, _ = fmt.Fprintf(w, "#  eval $(%s)\n", aliasCommand)
 }

--- a/aliases_test.go
+++ b/aliases_test.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPrintAliases(t *testing.T) {
+	cfg := &Cfg{commands: map[string]Handler{"test": &DockerRunHandler{true, "test", "8080:80", []string{}}}}
+
+	buffer := bytes.Buffer{}
+	printAliases(&buffer, cfg, true, true)
+
+	assert.Equal(t, "alias test='donner run --strict --fallback test';\n"+evalInstruction+"#  eval $(donner aliases --strict --fallback)\n", buffer.String())
+}

--- a/donner.go
+++ b/donner.go
@@ -53,7 +53,7 @@ func main() {
 				if err != nil {
 					return err
 				}
-				printAliases(cfg, c.Bool("strict"), c.Bool("fallback"))
+				printAliases(os.Stdout, cfg, c.Bool("strict"), c.Bool("fallback"))
 
 				return nil
 			},

--- a/handler.go
+++ b/handler.go
@@ -26,10 +26,12 @@ func (h *FallbackHandler) validate() error {
 	return nil
 }
 
-// DockerRunHandler wraps a command with `docker container run`
+// DockerRunHandler wraps a command with `docker run`
 type DockerRunHandler struct {
-	Remove bool
-	Image  string
+	Remove  bool
+	Image   string
+	Port    string
+	Volumes []string
 }
 
 // BuildCommand performs the actual wrapping of the command
@@ -42,6 +44,14 @@ func (h *DockerRunHandler) BuildCommand(command []string) []string {
 
 	if h.Image != "" {
 		wrappedCommand = append(wrappedCommand, h.Image)
+	}
+
+	if h.Port != "" {
+		wrappedCommand = append(wrappedCommand, "-p ", h.Port)
+	}
+
+	for _, v := range h.Volumes {
+		wrappedCommand = append(wrappedCommand, "-v ", v)
 	}
 
 	return append(wrappedCommand, command...)

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDockerRunHandler_BuildCommand(t *testing.T) {
+	want := []string{"docker", "run", "-it", "--rm", "test", "-p ", "8080:80", "-v ", "./:/opt/", "ls -la"}
+	dockerRunHandler := &DockerRunHandler{true, "test", "8080:80", []string{"./:/opt/"}}
+
+	got := dockerRunHandler.BuildCommand([]string{"ls -la"})
+
+	assert.Equal(t, want, got)
+}
+
+func TestComposeExecHandler_BuildCommand(t *testing.T) {
+	want := []string{"docker-compose", "exec", "gotest", "ls -la"}
+	composeExecHandler := &ComposeExecHandler{"gotest"}
+
+	got := composeExecHandler.BuildCommand([]string{"ls -la"})
+
+	assert.Equal(t, want, got)
+}
+
+func TestComposeRunHandler_BuildCommand(t *testing.T) {
+	want := []string{"docker-compose", "run", "--rm", "gotest", "ls -la"}
+	composeRunHandler := &ComposeRunHandler{true, "gotest"}
+
+	got := composeRunHandler.BuildCommand([]string{"ls -la"})
+
+	assert.Equal(t, want, got)
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -15,6 +15,9 @@ strategies:
   run_with_docker:
     handler: docker_run
     image: alpine:latest
+    port: "8080:80"
+    volumes:
+      - "./:/usr/src/app"
 
 default_strategy: run
 
@@ -23,22 +26,7 @@ commands:
   bundle: run
 `
 
-var yamlWithExtraAttributes = `
-strategies:
-  run:
-    handler: docker_compose_run
-    service: app
-    remove: true
-  run_with_docker:
-    handler: docker_run
-    image: alpine:latest
-
-default_strategy: run
-
-commands:
-  ls: run_with_docker
-  bundle: run
-
+var yamlWithExtraAttributes = fullYaml + `
 something-else:
   foo: bar
 `
@@ -54,6 +42,8 @@ func TestParseYaml(t *testing.T) {
 			"run_with_docker": {
 				"handler": "docker_run",
 				"image":   "alpine:latest",
+				"port":    "8080:80",
+				"volumes": []interface{}{"./:/usr/src/app"},
 			},
 		},
 		DefaultStrategy: "run",


### PR DESCRIPTION
This PR:

1. Extends the `docker run` stanza with the options to add a port mapping and volume mounts
2. Adds more tests/make the code more testable